### PR TITLE
MRS tasks + gait events

### DIFF
--- a/osimpipeline/postprocessing.py
+++ b/osimpipeline/postprocessing.py
@@ -626,15 +626,16 @@ def percent_duration(time, start=None, end=None):
 
 
 def toeoff_pgc(gl, side):
-    toeoff = gl[side + '_toeoff']
+    toeoff = getattr(gl, side + '_toeoff')
+    strike = getattr(gl, side + '_strike')
     cycle_duration = (gl.cycle_end - gl.cycle_start)
-    while toeoff < gl[side + '_strike']:
+    while toeoff < strike:
         toeoff += cycle_duration
-    while toeoff > gl[side + '_strike'] + cycle_duration:
+    while toeoff > strike + cycle_duration:
         toeoff -= cycle_duration
     return percent_duration_single(toeoff,
-            gl[side + '_strike'],
-            gl[side + '_strike'] + cycle_duration)
+            strike,
+            strike + cycle_duration)
 
 
 def plot_toeoff_pgc(gl, side, axes=None, *args, **kwargs):

--- a/osimpipeline/study.py
+++ b/osimpipeline/study.py
@@ -81,6 +81,7 @@ class Trial(object):
                 os.path.join(condition.rel_path, self.name))
         self.results_exp_path = os.path.join(self.study.config['results_path'],
                 'experiments', self.rel_path)
+        self.primary_leg=None
 
         def list_condition_names():
             """Iterate through all conditions under which this trial sits."""
@@ -125,12 +126,12 @@ class Trial(object):
         elif ((right_strikes and not left_strikes) or 
              (len(right_strikes) == len(left_strikes)+1)):
             heel_strikes=right_strikes
-            primary_leg='right'
+            self.primary_leg='right'
 
         elif ((left_strikes and not right_strikes) or 
              (len(left_strikes) == len(right_strikes)+1)):
             heel_strikes=left_strikes
-            primary_leg='left'
+            self.primary_leg='left'
 
         else:
             raise Exception("Invalid gait landmarks specified: ensure "
@@ -148,8 +149,8 @@ class Trial(object):
                     cycle_start=start,
                     cycle_end=end,
                     )
-            if primary_leg:
-                gait_landmarks.primary_leg = primary_leg
+            if self.primary_leg:
+                gait_landmarks.primary_leg = self.primary_leg
             if left_strikes:
                 gait_landmarks.left_strike = left_strikes[icycle]
             if left_toeoffs:

--- a/osimpipeline/study.py
+++ b/osimpipeline/study.py
@@ -4,26 +4,7 @@ import yaml
 from numpy import loadtxt
 
 import vital_tasks
-
-class GaitLandmarks(object):
-    def __init__(self,
-            primary_leg=None,
-            cycle_start=None,
-            cycle_end=None,
-            left_strike=None,
-            left_toeoff=None,
-            right_strike=None,
-            right_toeoff=None):
-        self.primary_leg  = primary_leg
-        self.cycle_start  = cycle_start
-        self.cycle_end    = cycle_end
-        self.left_strike  = left_strike
-        self.left_toeoff  = left_toeoff
-        self.right_strike = right_strike
-        self.right_toeoff = right_toeoff
-
-    def cycle_duration(self):
-        return self.cycle_end - self.cycle_start
+import utilities 
 
 class Cycle(object):
     """A subject may walk for multiple gait cycles in a given trial,
@@ -84,10 +65,12 @@ class Trial(object):
     Use the 'gait_events' dictionary argument to provide the events
     corresponding to individual gait cycles within a trial. A TrialTask will
     be created for each individual cycle. Either the 'right_strikes' or
-    'left_strikes' entry is required to create gait cycles. If the desired gait
-    cycles in the trial are not consecutive, then the 'stride_times' entry is 
-    also required. The opposite foot heel strikes and toeoffs from both feet
-    can be included as optional dictionary entries.
+    'left_strikes' entry is required to create gait cycles. If both are
+    provided, then the primary leg must have one more heel strike than the
+    opposite leg for consistency and automatic primary leg detection. If the
+    desired gait cycles in the trial are not consecutive, then the
+    'stride_times' entry is also required. The opposite foot heel strikes and
+    toeoffs from both feet can be included as optional dictionary entries.
 
     ```
     gait_events = dict()
@@ -205,7 +188,7 @@ class Trial(object):
                 end = start + self.stride_times[icycle]
             else:
                 end = self.heel_strikes[icycle + 1]
-            gait_landmarks = GaitLandmarks(
+            gait_landmarks = utilities.GaitLandmarks(
                     cycle_start=start,
                     cycle_end=end,
                     )
@@ -274,7 +257,7 @@ class Trial(object):
             if (("Inverse Kinematics" in task.doc) or 
                 ("Inverse Dynamics" in task.doc)):
                 raise Exception("TrialTask creation for individual cycles not "
-                    " current supported for the Inverse Kinematics and "
+                    " currently supported for the Inverse Kinematics and "
                     " Inverse Dynamics tools")
 
             tasks.append(task)

--- a/osimpipeline/task.py
+++ b/osimpipeline/task.py
@@ -141,11 +141,12 @@ class SetupTask(TrialTask):
             self.init_time = first_cycle.start
             self.final_time = last_cycle.end
 
-        self.source_extloads_fpath = os.path.join(trial.rel_path, self.tool,
+        self.source_path = os.path.join(trial.rel_path, self.tool)
+        self.source_extloads_fpath = os.path.join(self.source_path,
             'external_loads.xml')
         self.results_extloads_fpath = os.path.join(self.path,
                 os.path.basename(self.source_extloads_fpath))
-        self.source_tasks_fpath = os.path.join(trial.rel_path, self.tool,
+        self.source_tasks_fpath = os.path.join(self.source_path,
             'tasks.xml')
         self.results_tasks_fpath = os.path.join(self.path, 
                 os.path.basename(self.source_tasks_fpath))
@@ -163,6 +164,7 @@ class SetupTask(TrialTask):
                     )
 
     def create_external_loads_action(self):
+        self.add_source_dir()
         if (not os.path.exists(self.source_extloads_fpath) and 
             self.create_setup_deps):
             # The user does not yet have a external_loads.xml in place; fill 
@@ -182,6 +184,7 @@ class SetupTask(TrialTask):
                     self.copy_file) 
 
     def create_tasks_action(self):
+        self.add_source_dir()
         if (not os.path.exists(self.source_tasks_fpath) and
             self.create_setup_deps):
             # The user does not yet have a tasks.xml in place; fill out the
@@ -231,6 +234,8 @@ class SetupTask(TrialTask):
         cycle_path = os.path.join(self.tool_path, self.cycle.name)
         if not os.path.exists(cycle_path): os.makedirs(cycle_path)
 
+    def add_source_dir(self):
+        if not os.path.exists(self.source_path): os.makedirs(self.source_path)
 
 class ToolTask(TrialTask):
     def __init__(self, setup_task, trial, cycle=None,

--- a/osimpipeline/task.py
+++ b/osimpipeline/task.py
@@ -240,7 +240,7 @@ class SetupTask(TrialTask):
 
 class ToolTask(TrialTask):
     def __init__(self, setup_task, trial, cycle=None,
-                 exec_name=None, cmd=None, env=None):
+                 exec_name=None, cmd=None, env=None, opensim=True):
         super(ToolTask, self).__init__(trial)
         self.exec_name = exec_name
         self.cmd = cmd
@@ -252,24 +252,27 @@ class ToolTask(TrialTask):
         else:
             self.name = '%s_%s' % (trial.id, setup_task.tool)
 
-        self.file_dep = [
+        if opensim:
+            self.file_dep = [
                 '%s/setup.xml' % self.path
                 ]
 
-        if self.exec_name == None:
-            self.exec_name = setup_task.tool
-        if self.cmd == None:
-            cmd_action = CmdAction('"' + os.path.join(
-                self.study.config['opensim_home'],'bin',self.exec_name)
-                + '" -S setup.xml',
-                cwd=os.path.abspath(self.path),
-                env=self.env)
-        else:
-            cmd_action = CmdAction(self.cmd, cwd=os.path.abspath(self.path),
+            if self.exec_name == None:
+                self.exec_name = setup_task.tool
+
+            if self.cmd == None:
+                cmd_action = CmdAction('"' + os.path.join(
+                    self.study.config['opensim_home'],'bin',self.exec_name)
+                    + '" -S setup.xml',
+                    cwd=os.path.abspath(self.path),
                     env=self.env)
-        self.actions = [
-                cmd_action,
-                ]
+            else:
+                cmd_action = CmdAction(self.cmd, 
+                    cwd=os.path.abspath(self.path), env=self.env)
+
+            self.actions = [
+                    cmd_action,
+                    ]
 
 class PostTask(TrialTask):
     def __init__(self, setup_task, trial, cycle=None):

--- a/osimpipeline/task.py
+++ b/osimpipeline/task.py
@@ -153,8 +153,9 @@ class SetupTask(TrialTask):
         self.adjusted_model = '%s_adjusted.osim' % self.subject.name    
         self.adjusted_model_fpath = os.path.join(self.path, 
             self.adjusted_model)
-        self.results_setup_fpath = os.path.join(self.path, 'setup.xml')   
+        self.results_setup_fpath = os.path.join(self.path, 'setup.xml')  
 
+    def create_setup_action(self): 
         self.add_action(
                     ['templates/%s/setup.xml' % self.tool],
                     [self.results_setup_fpath],

--- a/osimpipeline/utilities.py
+++ b/osimpipeline/utilities.py
@@ -1,4 +1,6 @@
 
+import os
+
 class working_directory():
     """Use this to temporarily run code with some directory as a working
     directory and to then return to the original working directory::

--- a/osimpipeline/utilities.py
+++ b/osimpipeline/utilities.py
@@ -1,0 +1,35 @@
+
+class working_directory():
+    """Use this to temporarily run code with some directory as a working
+    directory and to then return to the original working directory::
+
+        with working_directory('<dir>'):
+            pass
+    """
+    def __init__(self, path):
+        self.path = path
+        self.original_working_dir = os.getcwd()
+    def __enter__(self):
+        os.chdir(self.path)
+    def __exit__(self, *exc_info):
+        os.chdir(self.original_working_dir)
+
+class GaitLandmarks(object):
+    def __init__(self,
+            primary_leg=None,
+            cycle_start=None,
+            cycle_end=None,
+            left_strike=None,
+            left_toeoff=None,
+            right_strike=None,
+            right_toeoff=None):
+        self.primary_leg  = primary_leg
+        self.cycle_start  = cycle_start
+        self.cycle_end    = cycle_end
+        self.left_strike  = left_strike
+        self.left_toeoff  = left_toeoff
+        self.right_strike = right_strike
+        self.right_toeoff = right_toeoff
+
+    def cycle_duration(self):
+        return self.cycle_end - self.cycle_start

--- a/osimpipeline/vital_tasks.py
+++ b/osimpipeline/vital_tasks.py
@@ -580,7 +580,7 @@ class TaskIDSetup(task.SetupTask):
             content = content.replace('@STUDYNAME@', self.study.name)
             content = content.replace('@NAME@', self.tricycle.id)
             content = content.replace('@MODEL@', 
-                os.path.relpath(self.subject.scaled_model_fpath), self.path)
+                os.path.relpath(self.subject.scaled_model_fpath, self.path))
             content = content.replace('@INIT_TIME@', '%.4f' % init_time)
             content = content.replace('@FINAL_TIME@', '%.4f' % final_time)
         
@@ -589,14 +589,14 @@ class TaskIDSetup(task.SetupTask):
 
 class TaskID(task.ToolTask):
     REGISTRY = []
-    def __init__(self, trial, id_setup_task, **kwargs):
+    def __init__(self, trial, id_setup_task, ik_setup_task, **kwargs):
         super(TaskID, self).__init__(id_setup_task, trial, **kwargs)
         self.doc = "Run OpenSim's Inverse Dynamics tool."
         self.file_dep += [
                 self.subject.scaled_model_fpath,
                 id_setup_task.results_extloads_fpath,
                 id_setup_task.results_setup_fpath,
-                os.path.join(self.path, '%s_%s_ik_solution.mot' % (
+                os.path.join(ik_setup_task.path, '%s_%s_ik_solution.mot' % (
                     self.study.name, id_setup_task.tricycle.id))
                 ]
         self.targets += [
@@ -872,8 +872,16 @@ class TaskCMC(task.ToolTask):
 
 class TaskMuscleRedundancySolverSetup(task.SetupTask):
     REGISTRY = []
-    def __init__(self, trial, platform='matlab', **kwargs):
+    def __init__(self, trial, **kwargs):
         super(TaskMuscleRedundancySolverSetup, self).__init__('mrs', trial, 
             **kwargs)
         self.doc = "Create a setup file for the Muscle Redundancy Solver tool."
-        
+        self.kinematics_file = os.path.join(self.trial.results_exp_path, 'ik',
+                '%s_%s_ik_solution.mot' % (self.study.name, self.trial.id))
+        self.rel_kinematics_file = os.path.relpath(self.kinematics_file,
+                self.path)
+        self.kinetics_file = os.path.join(self.trial.results_exp_path,
+                'id', 'results', '%s_%s_id_solution.sto' % ( self.study.name,
+                    self.trial.id))
+        self.rel_kinetics_file = os.path.relpath( self.kinetics_file,
+                self.path)

--- a/osimpipeline/vital_tasks.py
+++ b/osimpipeline/vital_tasks.py
@@ -9,6 +9,20 @@ import pylab as pl
 # Import postprocessing subroutines
 from postprocessing import plot_lower_limb_kinematics, plot_marker_error
 
+class working_directory():
+    """Use this to temporarily run code with some directory as a working
+    directory and to then return to the original working directory::
+
+        with working_directory('<dir>'):
+            pass
+    """
+    def __init__(self, path):
+        self.path = path
+        self.original_working_dir = os.getcwd()
+    def __enter__(self):
+        os.chdir(self.path)
+    def __exit__(self, *exc_info):
+        os.chdir(self.original_working_dir)
 
 class TaskCopyGenericModelFilesToResults(task.StudyTask):
     REGISTRY = []
@@ -567,9 +581,10 @@ class TaskIKPost(task.PostTask):
     
 class TaskIDSetup(task.SetupTask):
     REGISTRY = []
-    def __init__(self, trial, **kwargs):
+    def __init__(self, trial, ik_setup_task, **kwargs):
         super(TaskIDSetup, self).__init__('id', trial, **kwargs)
         self.doc = 'Create a setup file for Inverse Dynamics.'
+        self.ik_setup_task = ik_setup_task
 
         # Fill out external_loads.xml template and copy over to results 
         # directory
@@ -594,15 +609,15 @@ class TaskIDSetup(task.SetupTask):
 
 class TaskID(task.ToolTask):
     REGISTRY = []
-    def __init__(self, trial, id_setup_task, ik_setup_task, **kwargs):
+    def __init__(self, trial, id_setup_task, **kwargs):
         super(TaskID, self).__init__(id_setup_task, trial, **kwargs)
         self.doc = "Run OpenSim's Inverse Dynamics tool."
+        self.ik_setup_task = id_setup_task.ik_setup_task
         self.file_dep += [
                 self.subject.scaled_model_fpath,
                 id_setup_task.results_extloads_fpath,
                 id_setup_task.results_setup_fpath,
-                os.path.join(ik_setup_task.path, '%s_%s_ik_solution.mot' % (
-                    self.study.name, id_setup_task.tricycle.id))
+                os.path.join(self.ik_setup_task.path, '%s_%s_ik_solution.mot' % (self.study.name, id_setup_task.tricycle.id))
                 ]
         self.targets += [
                 os.path.join(self.path, '%s_%s_id_solution.mot' % (
@@ -884,26 +899,38 @@ class TaskCMC(task.ToolTask):
                 self.path, self.study.name, cmc_setup_task.tricycle.id, 
                 'cmc', cmc_output)]
 
-class TaskMuscleRedundancySolverSetup(task.SetupTask):
+class TaskMRSDeGrooteSetup(task.SetupTask):
     REGISTRY = []
     def __init__(self, trial, **kwargs):
-        super(TaskMuscleRedundancySolverSetup, self).__init__('mrs', trial, 
+        super(TaskMRSDeGrooteSetup, self).__init__('mrs', trial, 
             **kwargs)
-        self.doc = "Create a setup file for the Muscle Redundancy Solver tool."
+        self.doc = "Create a setup file for the DeGroote Muscle Redundancy Solver tool."
         self.kinematics_file = os.path.join(self.trial.results_exp_path, 'ik',
                 '%s_%s_ik_solution.mot' % (self.study.name, self.trial.id))
         self.rel_kinematics_file = os.path.relpath(self.kinematics_file,
                 self.path)
         self.kinetics_file = os.path.join(self.trial.results_exp_path,
-                'id', 'results', '%s_%s_id_solution.sto' % ( self.study.name,
+                'id', 'results', '%s_%s_id_solution.sto' % (self.study.name,
                     self.trial.id))
-        self.rel_kinetics_file = os.path.relpath( self.kinetics_file,
+        self.rel_kinetics_file = os.path.relpath(self.kinetics_file,
                 self.path)
-        self.results_setup_fpath = os.path.join(self.path, 'setup.m')  
+        self.results_setup_fpath = os.path.join(self.path, 'setup.m')
+        self.results_post_fpath = os.path.join(self.path, 'postprocess.m') 
         self.optctrlmuscle_path = self.study.config['optctrlmuscle_path']
+
+        self.file_dep += [
+            self.kinematics_file,
+            self.kinetics_file
+        ]
 
         # Fill out setup.m template and write to results directory
         self.create_setup_action()
+
+        # Fill out postprocess.m template and write to results directory
+        self.add_action(
+                ['templates/mrs/postprocess.m'],
+                [self.results_post_fpath],
+                self.fill_postprocess_template)
 
     def create_setup_action(self): 
         self.add_action(
@@ -940,3 +967,136 @@ class TaskMuscleRedundancySolverSetup(task.SetupTask):
 
         with open(target[0], 'w') as f:
             f.write(content)
+
+    def fill_postprocess_template(self, file_dep, target):
+        with open(file_dep[0]) as ft:
+            content = ft.read()
+            content = content.replace('@STUDYNAME@', self.study.name)
+            content = content.replace('@NAME@', self.tricycle.id)
+            content = content.replace('@REL_PATH_TO_TOOL@', os.path.relpath(
+                self.optctrlmuscle_path, self.path))
+            content = content.replace('@MODEL@', os.path.relpath(
+                self.subject.scaled_model_fpath, self.path))
+
+        with open(target[0], 'w') as f:
+            f.write(content)
+
+class TaskMRSDeGroote(task.ToolTask):
+    REGISTRY = []
+    def __init__(self, trial, mrs_setup_task, **kwargs):
+        kwargs['opensim'] = False
+        super(TaskMRSDeGroote, self).__init__(mrs_setup_task, trial, **kwargs)
+        self.doc = 'Run DeGroote Muscle Redundancy Solver in MATLAB.'
+
+        self.file_dep += [
+                os.path.join(self.path, 'setup.m'),
+                self.subject.scaled_model_fpath,
+                mrs_setup_task.kinematics_file,
+                mrs_setup_task.kinetics_file,
+                ]
+
+        self.actions += [
+                self.run_matlab,
+                ]
+
+        self.targets += [
+                os.path.join(self.path, '%s_%s_mrs.mat' % (self.study.name,
+                    mrs_setup_task.tricycle.id))
+                ]
+
+    def run_matlab(self):
+        with working_directory(self.path):
+            # On Mac, CmdAction was causing MATLAB ipopt with GPOPS output to
+            # not display properly.
+
+            status = os.system('matlab -nodisplay -nodesktop -nosplash '
+                    '-automation -logfile matlab_log.txt -r "try, '
+                    "run('%s'); disp('SUCCESS'); "
+                    'catch ME; disp(getReport(ME)); exit(2), end, exit(0);"\n'
+                    % (script_path.replace('\\','/'))
+                    )
+            if status != 0:
+                raise Exception('Non-zero exit status.')
+
+class TaskMRSDeGrootePost(task.PostTask):
+    REGISTRY = []
+    def __init__(self, trial, mrs_setup_task, **kwargs):
+        super(TaskMRSDeGrootePost, self).__init__(mrs_setup_task, trial, 
+            **kwargs)
+        self.doc = 'Postprocess DeGroote Muscle Redundancy Solver in MATLAB.'
+        self.id = mrs_setup_task.tricycle.id
+
+        self.file_dep += [
+                os.path.join(self.path, 'postprocess.m'),
+                os.path.join(self.path, '%s_%s_mrs.mat' % (self.study.name,
+                    self.id)),
+                ]
+
+        from doit.action import CmdAction
+        command = CmdAction('matlab -nodisplay -nodesktop -nosplash '
+                '-automation -logfile matlab_log_postprocess.txt -r "try, '
+                "postprocess; disp('SUCCESS'); "
+                'catch ME; disp(getReport(ME)); exit(2), end, exit(0);"',
+                cwd=os.path.abspath(self.path))
+        self.actions += [
+                command,
+                self.plot_results,
+                ]
+
+        self.targets += [
+                os.path.join(self.path, '%s_%s_mrs_lMtilde.csv' %
+                    (self.study.name, self.id)),
+                os.path.join(self.path, '%s_%s_mrs_MActivation.csv' %
+                    (self.study.name, self.id)),
+                os.path.join(self.path, '%s_%s_mrs_MExcitation.csv' %
+                    (self.study.name, self.id)),
+                os.path.join(self.path, '%s_%s_mrs_RActivation.csv' %
+                    (self.study.name, self.id)),
+                os.path.join(self.path, '%s_%s_mrs_TForce.csv' %
+                    (self.study.name, self.id)),
+                os.path.join(self.path, '%s_%s_mrs_TForcetilde.csv' %
+                    (self.study.name, self.id)),
+                # Plots:
+                os.path.join(self.path, 'muscle_activity.pdf'),
+                os.path.join(self.path, 'reserve_activity.pdf'),
+                ]
+
+    def plot_results(self):
+        with working_directory(self.path):
+            import pylab as pl
+            import numpy as np
+            df_a = pd.read_csv('%s_%s_mrs_MActivation.csv' % (self.study.name,
+                self.id), index_col=0)
+            df_e = pd.read_csv('%s_%s_mrs_MExcitation.csv' % (self.study.name,
+                self.id), index_col=0)
+            N = len(df_a.columns)
+            num_rows = 5
+            num_cols = np.ceil(float(N) / num_rows)
+            pl.figure(figsize=(11, 8.5))
+            for i in range(N):
+                pl.subplot(num_rows, num_cols, i + 1)
+                pl.plot(df_e.index, df_e[df_e.columns[i]], label='e')
+                pl.plot(df_a.index, df_a[df_a.columns[i]], label='a')
+                pl.ylim(0, 1)
+                if i == 1:
+                    pl.legend(frameon=False, fontsize=8)
+                pl.title(df_e.columns[i], fontsize=8)
+                pl.autoscale(enable=True, axis='x', tight=True)
+                pl.xticks([])
+                pl.yticks([])
+            pl.tight_layout()
+            pl.savefig('muscle_activity.pdf')
+
+            df_R = pd.read_csv('%s_%s_mrs_RActivation.csv' % (self.study.name,
+                self.id), index_col=0)
+            pl.figure()
+            NR = len(df_R.columns)
+            for i in range(NR):
+                pl.subplot(NR, 1, i + 1)
+                pl.plot(df_R.index, df_R[df_R.columns[i]])
+                pl.ylim(-1, 1)
+                pl.title(df_R.columns[i], fontsize=8)
+                pl.axhline(0)
+                pl.autoscale(enable=True, axis='x', tight=True)
+            pl.tight_layout()
+            pl.savefig('reserve_activity.pdf')


### PR DESCRIPTION
## Summary of changes
- The DeGroote muscle redundancy solver (MATLAB) has now been incorporated into `vital_tasks.py`, including setup, tool, and post tasks
- Gait events are now passed in as a dictionary argument when creating TrialTask objects for individual cycles
- The class `working_directory` has been copied to `vital_tasks.py`
- The class `GaitLandmarks` has been been copied to `study.py` 

## Comments
- The MRS implementation may need some refinement, but this can be done as needed while performing our device topology optimizations
- I thought `working_directory` and `GaitLandmarks` should live within osimpipeline, but I wasn't sure where to put them. Thoughts? Maybe we create another file for utility and/or helper classes?